### PR TITLE
Added facebook and twitter button

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,7 +20,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
-            android:text="GOOGLE SIGNIN"/>
+            android:text="GOOGLE SIGNIN" />
 
         <Button
             android:id="@+id/g_logout_btn"
@@ -50,34 +50,28 @@
 
         <Button
             android:id="@+id/bt_act_login_fb"
+            style="@style/FacebookSigninInButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
-            android:background="@drawable/corner_fb"
-            android:text="Facebook"
-            android:textAllCaps="true"
-            android:textColor="@android:color/white" />
+            android:text="Facebook" />
 
         <Button
             android:id="@+id/bt_act_logout_fb"
+            style="@style/FacebookSigninInButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
-            android:background="@drawable/corner_fb"
-            android:text="Facebook Logout"
-            android:textAllCaps="true"
-            android:textColor="@android:color/white" />
+            android:text="Facebook Logout" />
 
         <!--never change id of this button-->
         <Button
             android:id="@+id/twitter_login_button"
+            style="@style/TwitterSigninInButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
-            android:background="@color/twitter_color"
-            android:text="Login with Twitter"
-            android:textAllCaps="true"
-            android:textColor="@android:color/white" />
+            android:text="Login with Twitter" />
 
         <!--never change id of this button-->
         <Button

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,4 +17,23 @@
         <item name="android:background">@drawable/drawable_google</item>
         <item name="android:textColor">@android:color/white</item>
     </style>
+
+    <style name="FacebookSigninInButton">
+        <item name="android:background">@drawable/com_facebook_button_background</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:text">FACEBOOK SIGNIN</item>
+        <item name="android:drawableStart">@drawable/com_facebook_button_icon</item>
+        <item name="android:paddingLeft">16dp</item>
+        <item name="android:paddingRight">16dp</item>
+    </style>
+
+
+    <style name="TwitterSigninInButton">
+        <item name="android:background">@drawable/tw__login_btn</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:text">TWITTER SIGNIN</item>
+        <item name="android:drawableStart">@drawable/tw__ic_logo_default</item>
+        <item name="android:paddingLeft">8dp</item>
+        <item name="android:paddingRight">8dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
That's awesome that you are using Android Button View instead of Facebook and Twitter LoginView's. But it's always better to use the default resources for demo purpose, so that devs need not customize the icon and background of respective sdk's. I have added twitter, facebook default icon and background for login buttons instead of your own custom drawable. This helps devs to plug and play directly to their apps without adding extra drawables for Fb and twitter in the project. But this is just a suggestion, if this makes sense accept the PR.

![screenshot_2017-09-04-13-36-12-439](https://user-images.githubusercontent.com/11768239/30017396-9fe463d6-9176-11e7-9f2a-3f00e4ae7e03.jpeg)
